### PR TITLE
chore: updates for Xcode 15.2

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "Quick/Nimble" "v9.2.1"
+github "Quick/Nimble" ~> 12.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v9.2.1"
+github "Quick/Nimble" "v12.3.0"
 github "ably/ably-cocoa" "1.2.10"
 github "ably/delta-codec-cocoa" "1.3.2"
 github "mobilejazz/harmony-swift" "2.0.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "Quick/Nimble" "v12.3.0"
-github "ably/ably-cocoa" "1.2.10"
-github "ably/delta-codec-cocoa" "1.3.2"
+github "ably/ably-cocoa" "1.2.27"
+github "ably/delta-codec-cocoa" "1.3.3"
 github "mobilejazz/harmony-swift" "2.0.0"
 github "rvi/msgpack-objective-C" "0.4.0"

--- a/MagicBell.podspec
+++ b/MagicBell.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/**/*.swift'
 
   s.dependency 'Harmony', '2.0.0'
-  s.dependency 'Ably', '1.2.7'
+  s.dependency 'Ably', '1.2.27'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/mobilejazz/harmony-swift", from: "2.0.0"),
-        .package(url: "https://github.com/ably/ably-cocoa", from: "1.2.27")
+        .package(url: "https://github.com/ably/ably-cocoa", from: "1.2.27"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "12.0.0")
     ],
     targets: [
         .target(
@@ -27,6 +28,9 @@ let package = Package(
                 .product(name: "Ably", package: "ably-cocoa")
             ],
             path: "Source"
-        )
+        ),
+        .testTarget(name: "MagicBellTests",
+                    dependencies: [ "Nimble", "MagicBell" ],
+                    path: "Tests")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/mobilejazz/harmony-swift", from: "2.0.0"),
-        .package(url: "https://github.com/ably/ably-cocoa", from: "1.2.0")
+        .package(url: "https://github.com/ably/ably-cocoa", from: "1.2.27")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ assert(userOne === userTwo, "Both users reference to the same instance")
 
 ### Multi-User Support
 
-If your app suports multiple logins, you may want to display the status of notifications for all logged-in users
-simultaneously. The MagicBell SDK allows you to that.
+If your app supports multiple logins, you may want to display the status of notifications for all logged-in users
+simultaneously. The MagicBell SDK allows you to do that.
 
 You can call the `connectUser(:)` method with the email or external ID of your logged in users as many times as you
 need.
@@ -562,7 +562,7 @@ user.preferences.fetch { result in
 }
 ```
 
-It is also possible to fetch preference for a category using the `fetchPreferences(for:)` method:
+It is also possible to fetch preferences for a category using the `fetchPreferences(for:)` method:
 
 ```swift
 user.preferences.fetchPreferences(for: "new_comment") { result in


### PR DESCRIPTION
## What's in this PR?

This PR updates two dependencies to make them compile with Xcode 15.2:
- Nimble (used for tests, and only referenced via Carthage, but not via Cocoapods spec and SwiftPM manifest)
- Ably

The errors appeared when trying to install the development dependencies for working on `MagicBell.xcodeproj`. For this one has to first run `carthage bootstrap --use-xcframeworks --no-use-binaries` which resulted in these two errors (line breaks added for readability):

```
/Users/ullrich/Projects/magicbell-swift/Carthage/Checkouts/Nimble/Nimble.xcodeproj: warning: 
The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.10, but the range
of supported deployment target versions is 10.13 to 14.2.99. (in target 'Nimble-macOS' from project 'Nimble')
** ARCHIVE FAILED **
```

```
/Users/ullrich/Projects/magicbell-swift/Carthage/Checkouts/ably-cocoa/Ably.xcodeproj: warning:
The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.12, but the range
of supported deployment target versions is 10.13 to 14.2.99. (in target 'Ably-macOS' from project 'Ably')
** ARCHIVE FAILED **
```

Xcode versions 14 and above only support a minimum deployment target of 10.13 (documented [here](https://developer.apple.com/support/xcode/)).

## Drive By changes

- Fixed a few typos in the readme
- Added a test target to the swift package manager manifest (allows to run unit tests via `swift test` from the CLI)

## Test Plan

### Carthage

To reproduce the issue and verify the fix make sure to have Carthage installed and follow these steps:
- Clone the project
- Run the following command in the projects root: `carthage bootstrap --use-xcframeworks --no-use-binaries` (⚠️ this will fail without the changes in this PR for Nimble and Ably)
- 🍵 wait until the Carthage dependencies finished building
- Open `MagicBell.xcodeproj`
- Select the `MagicBellTests` target and a Simulator as a testing device
- Press `⌘+U` to build and run tests

### Cocoapods

Tested by running the Example app that integrates the SDK via Cocoapods.

### SwiftPM

Added a unit test target to SPM and ran the tests via `swift test`