### PR TITLE
chore: add Magicbell licence preamble where missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ playground.xcworkspace
 Packages/
 Package.pins
 Package.resolved
-*.xcodeproj
+
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project

--- a/Example/Example.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/Example/Example.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>
+// By downloading or using this software made available by MagicBell, Inc.
+// (&quot;MagicBell&quot;) or any documentation that accompanies it (collectively, the
+// &quot;Software&quot;), you and the company or entity that you represent (collectively,
+// &quot;you&quot; or &quot;your&quot;) are consenting to be bound by and are becoming a party to this
+// License Agreement (this &quot;Agreement&quot;). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
+//
+// For more information, read the LICENSE file.
+//</string>
+</dict>
+</plist>

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -1,8 +1,14 @@
 //
-//  AppDelegate.swift
-//  Example
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Javi on 17/11/21.
+// For more information, read the LICENSE file.
 //
 
 import UIKit

--- a/Example/Example/Helpers/Appearance.swift
+++ b/Example/Example/Helpers/Appearance.swift
@@ -1,8 +1,14 @@
 //
-//  Appearance.swift
-//  Example
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Joan Martin on 28/12/21.
+// For more information, read the LICENSE file.
 //
 
 import Foundation

--- a/Example/Example/Helpers/UIHostingViewController.swift
+++ b/Example/Example/Helpers/UIHostingViewController.swift
@@ -1,8 +1,14 @@
 //
-//  UIHostingViewController.swift
-//  Example
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Joan Martin on 28/12/21.
+// For more information, read the LICENSE file.
 //
 
 import Foundation

--- a/Example/Example/SceneDelegate.swift
+++ b/Example/Example/SceneDelegate.swift
@@ -1,8 +1,14 @@
 //
-//  SceneDelegate.swift
-//  Example
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Javi on 17/11/21.
+// For more information, read the LICENSE file.
 //
 
 import UIKit

--- a/Example/Example/SwiftUI/MagicBellView.swift
+++ b/Example/Example/SwiftUI/MagicBellView.swift
@@ -1,8 +1,14 @@
 //
-//  MagicBellView.swift
-//  Example
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Joan Martin on 28/12/21.
+// For more information, read the LICENSE file.
 //
 
 import SwiftUI

--- a/Example/Example/UIKit/BadgeBarButtonItem.swift
+++ b/Example/Example/UIKit/BadgeBarButtonItem.swift
@@ -1,8 +1,14 @@
 //
-//  BadgeBarButtonItem.swift
-//  Example
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Javi on 6/12/21.
+// For more information, read the LICENSE file.
 //
 
 import UIKit

--- a/Example/Example/UIKit/MagicBellStoreCell.swift
+++ b/Example/Example/UIKit/MagicBellStoreCell.swift
@@ -1,8 +1,14 @@
 //
-//  MagicBellStoreCell.swift
-//  Example
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Joan Martin on 2/12/21.
+// For more information, read the LICENSE file.
 //
 
 import UIKit

--- a/Example/Example/UIKit/MagicBellStoreViewController.swift
+++ b/Example/Example/UIKit/MagicBellStoreViewController.swift
@@ -1,8 +1,14 @@
 //
-//  MagicBellStoreViewController.swift
-//  Example
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Javi on 17/11/21.
+// For more information, read the LICENSE file.
 //
 
 import UIKit

--- a/MagicBell.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/MagicBell.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>
+// By downloading or using this software made available by MagicBell, Inc.
+// (&quot;MagicBell&quot;) or any documentation that accompanies it (collectively, the
+// &quot;Software&quot;), you and the company or entity that you represent (collectively,
+// &quot;you&quot; or &quot;your&quot;) are consenting to be bound by and are becoming a party to this
+// License Agreement (this &quot;Agreement&quot;). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
+//
+// For more information, read the LICENSE file.
+//</string>
+</dict>
+</plist>

--- a/Source/Features/Store/Stores.swift
+++ b/Source/Features/Store/Stores.swift
@@ -1,8 +1,14 @@
 //
-//  Stores.swift
-//  MagicBell
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Javi on 25/11/21.
+// For more information, read the LICENSE file.
 //
 
 import Foundation

--- a/Tests/Common/Utils/BoolObjectMother.swift
+++ b/Tests/Common/Utils/BoolObjectMother.swift
@@ -1,8 +1,14 @@
 //
-//  BoolObjectMother.swift
-//  MagicBell
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Javi on 28/1/22.
+// For more information, read the LICENSE file.
 //
 
 import Foundation

--- a/Tests/Common/Utils/IntMotherObject.swift
+++ b/Tests/Common/Utils/IntMotherObject.swift
@@ -1,8 +1,14 @@
 //
-//  IntMotherObject.swift
-//  MagicBell
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Javi on 28/1/22.
+// For more information, read the LICENSE file.
 //
 
 import Foundation

--- a/Tests/Common/Utils/ResultUtils.swift
+++ b/Tests/Common/Utils/ResultUtils.swift
@@ -1,8 +1,14 @@
 //
-//  ResultUtils.swift
-//  MagicBell
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Javi on 28/1/22.
+// For more information, read the LICENSE file.
 //
 
 import Foundation

--- a/Tests/Common/Utils/StringMotherObject.swift
+++ b/Tests/Common/Utils/StringMotherObject.swift
@@ -1,8 +1,14 @@
 //
-//  StringMotherObject.swift
-//  MagicBell
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Javi on 28/1/22.
+// For more information, read the LICENSE file.
 //
 
 import Foundation

--- a/Tests/Features/Store/NotificationStoreCombineTests.swift
+++ b/Tests/Features/Store/NotificationStoreCombineTests.swift
@@ -1,8 +1,14 @@
 //
-//  NotificationStoreCombineTests.swift
-//  MagicBell
+// By downloading or using this software made available by MagicBell, Inc.
+// ("MagicBell") or any documentation that accompanies it (collectively, the
+// "Software"), you and the company or entity that you represent (collectively,
+// "you" or "your") are consenting to be bound by and are becoming a party to this
+// License Agreement (this "Agreement"). You hereby represent and warrant that you
+// are authorized and lawfully able to bind such company or entity that you
+// represent to this Agreement.  If you do not have such authority or do not agree
+// to all of the terms of this Agreement, you may not download or use the Software.
 //
-//  Created by Javi on 27/12/21.
+// For more information, read the LICENSE file.
 //
 
 @testable import MagicBell


### PR DESCRIPTION
Drive-by update of header comments to include the Magicbell license like in other files.

No semantic change to code.

I've also updated the Xcode projects so that all newly created files contain a valid header.