### PR TITLE
feat: handle the ability to add a HMAC instead of generate it

### DIFF
--- a/Source/Common/Query/UserQuery.swift
+++ b/Source/Common/Query/UserQuery.swift
@@ -18,22 +18,26 @@ class UserQuery: KeyQuery {
     let externalId: String?
     let email: String?
     let key: String
+    let hmac: String?
 
-    init(externalId: String, email: String) {
+    init(externalId: String, email: String, hmac: String? = nil) {
         self.externalId = externalId
         self.email = email
         self.key = externalId
+        self.hmac = hmac
     }
 
-    init(externalId: String) {
+    init(externalId: String, hmac: String? = nil) {
         self.externalId = externalId
         self.email = nil
         self.key = externalId
+        self.hmac = hmac
     }
 
-    init(email: String) {
+    init(email: String, hmac: String? = nil) {
         self.externalId = nil
         self.email = email
         self.key = email
+        self.hmac = hmac
     }
 }

--- a/Source/Features/Config/Data/ConfigNetworkDataSource.swift
+++ b/Source/Features/Config/Data/ConfigNetworkDataSource.swift
@@ -32,7 +32,8 @@ class ConfigNetworkDataSource: GetDataSource {
             let urlRequest = httpClient.prepareURLRequest(
                 path: "/config",
                 externalId: userQuery.externalId,
-                email: userQuery.email
+                email: userQuery.email,
+                hmac: userQuery.hmac
             )
             return httpClient
                 .performRequest(urlRequest)

--- a/Source/Features/Notification/Data/ActionNotificationNetworkDataSource.swift
+++ b/Source/Features/Notification/Data/ActionNotificationNetworkDataSource.swift
@@ -46,7 +46,8 @@ class ActionNotificationNetworkDataSource: PutDataSource, DeleteDataSource {
             var urlRequest = self.httpClient.prepareURLRequest(
                 path: path,
                 externalId: notificationActionQuery.user.externalId,
-                email: notificationActionQuery.user.email
+                email: notificationActionQuery.user.email,
+                hmac: notificationActionQuery.user.hmac
             )
             
             urlRequest.httpMethod = httpMethod
@@ -71,7 +72,8 @@ class ActionNotificationNetworkDataSource: PutDataSource, DeleteDataSource {
             var urlRequest = self.httpClient.prepareURLRequest(
                 path: "/notifications/\(notificationQuery.notificationId)",
                 externalId: notificationQuery.user.externalId,
-                email: notificationQuery.user.email
+                email: notificationQuery.user.email,
+                hmac: notificationQuery.user.hmac
             )
             urlRequest.httpMethod = "DELETE"
             

--- a/Source/Features/Notification/Data/NotificationNetworkDataSource.swift
+++ b/Source/Features/Notification/Data/NotificationNetworkDataSource.swift
@@ -34,7 +34,8 @@ class NotificationNetworkDataSource: GetDataSource {
             let urlRequest = self.httpClient.prepareURLRequest(
                 path: "/notifications/\(notificationQuery.notificationId)",
                 externalId: notificationQuery.user.externalId,
-                email: notificationQuery.user.email
+                email: notificationQuery.user.email,
+                hmac: notificationQuery.user.hmac
             )
             return self.httpClient
                 .performRequest(urlRequest)

--- a/Source/Features/NotificationPreferences/Data/NotificationPreferencesNetworkDataSource.swift
+++ b/Source/Features/NotificationPreferences/Data/NotificationPreferencesNetworkDataSource.swift
@@ -33,6 +33,7 @@ class NotificationPreferencesNetworkDataSource: GetDataSource, PutDataSource {
                 path: "/notification_preferences",
                 externalId: userQuery.externalId,
                 email: userQuery.email,
+                hmac: userQuery.hmac,
                 additionalHTTPHeaders: ["accept-version": "v2"]
             )
             return self.httpClient
@@ -60,6 +61,7 @@ class NotificationPreferencesNetworkDataSource: GetDataSource, PutDataSource {
                 path: "/notification_preferences",
                 externalId: userQuery.externalId,
                 email: userQuery.email,
+                hmac: userQuery.hmac,
                 additionalHTTPHeaders: ["accept-version": "v2"]
             )
             urlRequest.httpMethod = "PUT"

--- a/Source/Features/PushSubscription/Data/PushSubscriptionNetworkDataSource.swift
+++ b/Source/Features/PushSubscription/Data/PushSubscriptionNetworkDataSource.swift
@@ -37,7 +37,8 @@ class PushSubscriptionNetworkDataSource: PutDataSource, DeleteDataSource {
             var urlRequest = httpClient.prepareURLRequest(
                 path: "/push_subscriptions",
                 externalId: pushSubscriptionQuery.user.externalId,
-                email: pushSubscriptionQuery.user.email
+                email: pushSubscriptionQuery.user.email,
+                hmac: pushSubscriptionQuery.user.hmac
             )
             urlRequest.httpMethod = "POST"
             do {
@@ -66,7 +67,8 @@ class PushSubscriptionNetworkDataSource: PutDataSource, DeleteDataSource {
             var urlRequest = self.httpClient.prepareURLRequest(
                 path: "/push_subscriptions/\(deletePushSubscriptionQuery.deviceToken)",
                 externalId: deletePushSubscriptionQuery.user.externalId,
-                email: deletePushSubscriptionQuery.user.email
+                email: deletePushSubscriptionQuery.user.email,
+                hmac: deletePushSubscriptionQuery.user.hmac
             )
             urlRequest.httpMethod = "DELETE"
 

--- a/Source/Features/Store/Data/StoresGraphQLDataSource.swift
+++ b/Source/Features/Store/Data/StoresGraphQLDataSource.swift
@@ -34,7 +34,8 @@ class StoresGraphQLDataSource: GetDataSource {
             var urlRequest = httpClient.prepareURLRequest(
                 path: "/graphql",
                 externalId: query.userQuery.externalId,
-                email: query.userQuery.email
+                email: query.userQuery.email,
+                hmac: query.userQuery.hmac
             )
             urlRequest.allHTTPHeaderFields = ["content-type": "application/json"]
             urlRequest.httpMethod = "POST"

--- a/Source/Features/StoreRealTime/AblyConnector.swift
+++ b/Source/Features/StoreRealTime/AblyConnector.swift
@@ -73,6 +73,7 @@ class AblyConnector: StoreRealTime {
             apiSecret: self.environment.apiSecret,
             isHMACEnabled: self.environment.isHMACEnabled,
             externalId: self.userQuery.externalId,
+            hmac: self.userQuery.hmac,
             email: self.userQuery.email
         )
         options.authHeaders = headers
@@ -100,6 +101,7 @@ class AblyConnector: StoreRealTime {
         apiSecret: String?,
         isHMACEnabled: Bool,
         externalId: String?,
+        hmac: String?,
         email: String?
     ) -> [String: String] {
 
@@ -113,6 +115,8 @@ class AblyConnector: StoreRealTime {
                 let hmac = email.hmac(key: apiSecret)
                 headers["X-MAGICBELL-USER-HMAC"] = hmac
             }
+        } else if let hmac = hmac {
+            headers["X-MAGICBELL-USER-HMAC"] = hmac
         }
 
         if let externalId = externalId {


### PR DESCRIPTION
Hi ! 

On my side, I just add the ability to set a user HMAC on UserQuery. But I let the option to generate the HMAC (dont know if some users are using this HMAC generation in the app so I didn't take the choice to remove it). 

If the HMAC generation is enabled and SecretKey set, it's still the default behaviour (the SDK compute a HMAC and set it as header). But if isHMACEnabled == false  OR SecretKey == nil, so I check if an HMAC parameter has been passed and add it in the headers. 

 