### PR TITLE
feat: add function to update channel in notifications preferences

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		59EF9A9B2744700700FB2378 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 59EF9A992744700700FB2378 /* Main.storyboard */; };
 		59EF9A9D2744700800FB2378 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 59EF9A9C2744700800FB2378 /* Assets.xcassets */; };
 		59EF9AA02744700800FB2378 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 59EF9A9E2744700800FB2378 /* LaunchScreen.storyboard */; };
+		942497092BC1F76A006A3D3A /* NotificationPreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942497082BC1F76A006A3D3A /* NotificationPreferencesViewController.swift */; };
+		94C074CE2BC212C5001615CF /* NotificationChannelsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C074CD2BC212C5001615CF /* NotificationChannelsViewController.swift */; };
 		D2DC15F62758C68000282C27 /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DC15F52758C68000282C27 /* UIColorExtensions.swift */; };
 		D2DC15F82758CC0B00282C27 /* MagicBellStoreCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DC15F72758CC0B00282C27 /* MagicBellStoreCell.swift */; };
 		D2E4B088277B5EA500E9E98F /* MagicBellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E4B087277B5E8A00E9E98F /* MagicBellView.swift */; };
@@ -35,6 +37,8 @@
 		59EF9A9F2744700800FB2378 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		59EF9AA12744700800FB2378 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		911386F4690B2C7C97254425 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
+		942497082BC1F76A006A3D3A /* NotificationPreferencesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreferencesViewController.swift; sourceTree = "<group>"; };
+		94C074CD2BC212C5001615CF /* NotificationChannelsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationChannelsViewController.swift; sourceTree = "<group>"; };
 		D2DC15F52758C68000282C27 /* UIColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtensions.swift; sourceTree = "<group>"; };
 		D2DC15F72758CC0B00282C27 /* MagicBellStoreCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagicBellStoreCell.swift; sourceTree = "<group>"; };
 		D2E4B087277B5E8A00E9E98F /* MagicBellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagicBellView.swift; sourceTree = "<group>"; };
@@ -102,6 +106,8 @@
 				599A9206275E702600656E32 /* BadgeBarButtonItem.swift */,
 				59EF9A972744700700FB2378 /* MagicBellStoreViewController.swift */,
 				D2DC15F72758CC0B00282C27 /* MagicBellStoreCell.swift */,
+				942497082BC1F76A006A3D3A /* NotificationPreferencesViewController.swift */,
+				94C074CD2BC212C5001615CF /* NotificationChannelsViewController.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -271,9 +277,11 @@
 				D2DC15F82758CC0B00282C27 /* MagicBellStoreCell.swift in Sources */,
 				59EF9A942744700700FB2378 /* AppDelegate.swift in Sources */,
 				D2E4B08B277B5EDF00E9E98F /* Appearance.swift in Sources */,
+				942497092BC1F76A006A3D3A /* NotificationPreferencesViewController.swift in Sources */,
 				D2E4B088277B5EA500E9E98F /* MagicBellView.swift in Sources */,
 				59EF9A962744700700FB2378 /* SceneDelegate.swift in Sources */,
 				599A9207275E702600656E32 /* BadgeBarButtonItem.swift in Sources */,
+				94C074CE2BC212C5001615CF /* NotificationChannelsViewController.swift in Sources */,
 				D2E4B08D277B619F00E9E98F /* UIHostingViewController.swift in Sources */,
 				D2DC15F62758C68000282C27 /* UIColorExtensions.swift in Sources */,
 			);

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -18,7 +18,7 @@ import UserNotifications
 extension MagicBellClient {
     /// Application global instance of MagicBellClient
     static var shared = MagicBellClient(
-        apiKey: "34ed17a8482e44c765d9e163015a8d586f0b3383",
+        apiKey: "d75bb407731e0be07547ad7d2f1c3aae3ebc1ec1",
         logLevel: .debug
     )
 }

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,110 +1,194 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lZK-lU-qnt">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="c86-aB-m1b">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Magic Bell Store View Controller-->
-        <scene sceneID="gVc-Sm-Cby">
+        <scene sceneID="7C4-wm-y0P">
             <objects>
-                <viewController id="lZK-lU-qnt" customClass="MagicBellStoreViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="1gY-C4-fhJ">
+                <tableViewController id="4gu-B9-Aej" customClass="MagicBellStoreViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="idf-4I-m7Z">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="6oO-SZ-63H" userLabel="TableView">
-                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MagicBellStoreCell" rowHeight="118" id="UI7-jX-o5A" customClass="MagicBellStoreCell" customModule="Example" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="118"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UI7-jX-o5A" id="TzE-f9-ylV">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="118"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Notification Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KPh-St-cK7">
-                                                    <rect key="frame" x="20" y="20" width="374" height="19.5"/>
-                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="muz-gF-hk8">
-                                                    <rect key="frame" x="20" y="47.5" width="374" height="50.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="muz-gF-hk8" firstAttribute="top" secondItem="KPh-St-cK7" secondAttribute="bottom" constant="8" id="4Aj-Qf-hGM"/>
-                                                <constraint firstItem="KPh-St-cK7" firstAttribute="top" secondItem="TzE-f9-ylV" secondAttribute="top" constant="20" id="SWY-tf-cap"/>
-                                                <constraint firstAttribute="trailing" secondItem="muz-gF-hk8" secondAttribute="trailing" constant="20" id="W5H-eA-VhI"/>
-                                                <constraint firstItem="muz-gF-hk8" firstAttribute="leading" secondItem="TzE-f9-ylV" secondAttribute="leading" constant="20" id="ilV-I8-jdg"/>
-                                                <constraint firstAttribute="bottom" secondItem="muz-gF-hk8" secondAttribute="bottom" constant="20" id="mpb-ai-XSk"/>
-                                                <constraint firstItem="KPh-St-cK7" firstAttribute="leading" secondItem="TzE-f9-ylV" secondAttribute="leading" constant="20" id="nKk-wK-h1h"/>
-                                                <constraint firstAttribute="trailing" secondItem="KPh-St-cK7" secondAttribute="trailing" constant="20" id="tgJ-vA-mpl"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <outlet property="bodyLabel" destination="muz-gF-hk8" id="4kc-O5-z0O"/>
-                                            <outlet property="titleLabel" destination="KPh-St-cK7" id="83C-LY-L6T"/>
-                                        </connections>
-                                    </tableViewCell>
-                                </prototypes>
-                                <connections>
-                                    <outlet property="dataSource" destination="lZK-lU-qnt" id="aeW-TX-Byv"/>
-                                    <outlet property="delegate" destination="lZK-lU-qnt" id="jLH-tp-tlI"/>
-                                </connections>
-                            </tableView>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sd2-16-lC1">
-                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                                <items>
-                                    <navigationItem title="Title" id="HHV-mh-iZF">
-                                        <barButtonItem key="leftBarButtonItem" systemItem="edit" id="d6H-f0-Cjz">
-                                            <connections>
-                                                <action selector="menuAction:" destination="lZK-lU-qnt" id="yg7-Mb-toj"/>
-                                            </connections>
-                                        </barButtonItem>
-                                        <barButtonItem key="rightBarButtonItem" title="Item" image="magicbellicon" id="GM4-eK-tpy" customClass="BadgeBarButtonItem" customModule="Example" customModuleProvider="target">
-                                            <connections>
-                                                <action selector="globalAction:" destination="lZK-lU-qnt" id="4DT-5y-LgZ"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                                <connections>
-                                    <outlet property="delegate" destination="lZK-lU-qnt" id="bpK-4l-qiN"/>
-                                </connections>
-                            </navigationBar>
-                        </subviews>
-                        <viewLayoutGuide key="safeArea" id="cIQ-wn-H30"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="6oO-SZ-63H" firstAttribute="top" secondItem="sd2-16-lC1" secondAttribute="bottom" id="1U4-D1-gmO"/>
-                            <constraint firstItem="6oO-SZ-63H" firstAttribute="trailing" secondItem="cIQ-wn-H30" secondAttribute="trailing" id="DYg-2x-jCp"/>
-                            <constraint firstItem="sd2-16-lC1" firstAttribute="top" secondItem="cIQ-wn-H30" secondAttribute="top" id="M4V-WZ-pTC"/>
-                            <constraint firstItem="sd2-16-lC1" firstAttribute="trailing" secondItem="cIQ-wn-H30" secondAttribute="trailing" id="XVa-Ch-OAi"/>
-                            <constraint firstItem="6oO-SZ-63H" firstAttribute="leading" secondItem="cIQ-wn-H30" secondAttribute="leading" id="jW4-JR-Oms"/>
-                            <constraint firstAttribute="bottom" secondItem="6oO-SZ-63H" secondAttribute="bottom" id="mat-NC-8wc"/>
-                            <constraint firstItem="sd2-16-lC1" firstAttribute="leading" secondItem="cIQ-wn-H30" secondAttribute="leading" id="sPG-oW-DrB"/>
-                        </constraints>
-                    </view>
-                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MagicBellStoreCell" rowHeight="118" id="UI7-jX-o5A" customClass="MagicBellStoreCell" customModule="Example" customModuleProvider="target">
+                                <rect key="frame" x="20" y="55.5" width="374" height="118"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UI7-jX-o5A" id="TzE-f9-ylV">
+                                    <rect key="frame" x="0.0" y="0.0" width="374" height="118"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Notification Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KPh-St-cK7">
+                                            <rect key="frame" x="20" y="20" width="334" height="19.5"/>
+                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="muz-gF-hk8">
+                                            <rect key="frame" x="20" y="47.5" width="334" height="50.5"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="muz-gF-hk8" firstAttribute="top" secondItem="KPh-St-cK7" secondAttribute="bottom" constant="8" id="4Aj-Qf-hGM"/>
+                                        <constraint firstItem="KPh-St-cK7" firstAttribute="top" secondItem="TzE-f9-ylV" secondAttribute="top" constant="20" id="SWY-tf-cap"/>
+                                        <constraint firstAttribute="trailing" secondItem="muz-gF-hk8" secondAttribute="trailing" constant="20" id="W5H-eA-VhI"/>
+                                        <constraint firstItem="muz-gF-hk8" firstAttribute="leading" secondItem="TzE-f9-ylV" secondAttribute="leading" constant="20" id="ilV-I8-jdg"/>
+                                        <constraint firstAttribute="bottom" secondItem="muz-gF-hk8" secondAttribute="bottom" constant="20" id="mpb-ai-XSk"/>
+                                        <constraint firstItem="KPh-St-cK7" firstAttribute="leading" secondItem="TzE-f9-ylV" secondAttribute="leading" constant="20" id="nKk-wK-h1h"/>
+                                        <constraint firstAttribute="trailing" secondItem="KPh-St-cK7" secondAttribute="trailing" constant="20" id="tgJ-vA-mpl"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="bodyLabel" destination="muz-gF-hk8" id="4kc-O5-z0O"/>
+                                    <outlet property="titleLabel" destination="KPh-St-cK7" id="83C-LY-L6T"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <sections/>
+                        <connections>
+                            <outlet property="dataSource" destination="4gu-B9-Aej" id="zVh-xT-QdZ"/>
+                            <outlet property="delegate" destination="4gu-B9-Aej" id="rar-b6-7sf"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="CGK-c1-EFe">
+                        <barButtonItem key="leftBarButtonItem" systemItem="edit" id="d6H-f0-Cjz">
+                            <connections>
+                                <action selector="menuAction:" destination="4gu-B9-Aej" id="EZs-8s-hff"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="Item" image="magicbellicon" id="GM4-eK-tpy" customClass="BadgeBarButtonItem" customModule="Example" customModuleProvider="target">
+                            <connections>
+                                <action selector="globalAction:" destination="4gu-B9-Aej" id="2p6-R4-FcM"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
-                        <outlet property="magicBellStoreItem" destination="GM4-eK-tpy" id="pSR-bV-lQJ"/>
-                        <outlet property="navigationBar" destination="sd2-16-lC1" id="cV2-N7-dHm"/>
-                        <outlet property="tableView" destination="6oO-SZ-63H" id="SGG-jg-fy2"/>
+                        <outlet property="magicBellStoreItem" destination="GM4-eK-tpy" id="wkW-vk-m8h"/>
+                        <segue destination="egA-1I-S3M" kind="show" identifier="preferences" id="sQn-bC-uzi"/>
                     </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Og6-5d-Zb9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Bfx-tM-9nV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-223.18840579710147" y="-77.008928571428569"/>
+            <point key="canvasLocation" x="897.10144927536237" y="-750"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="8Dy-da-tRL">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="c86-aB-m1b" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="icj-aK-gVg">
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="4gu-B9-Aej" kind="relationship" relationship="rootViewController" id="SYm-Dn-kVg"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="hvW-Lr-lAj" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-13.043478260869566" y="-750"/>
+        </scene>
+        <!--Notification Preferences View Controller-->
+        <scene sceneID="7ep-ro-U8F">
+            <objects>
+                <tableViewController id="egA-1I-S3M" customClass="NotificationPreferencesViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="RH0-UG-Ve7">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" textLabel="Ebk-nB-Waw" detailTextLabel="qyO-FD-yQm" style="IBUITableViewCellStyleValue1" id="xdl-Zq-y6g">
+                                <rect key="frame" x="0.0" y="50" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xdl-Zq-y6g" id="Uz8-mH-YaB">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ebk-nB-Waw">
+                                            <rect key="frame" x="20" y="15" width="25" height="14.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qyO-FD-yQm">
+                                            <rect key="frame" x="361" y="15" width="33" height="14.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <segue destination="kBu-Ct-cvV" kind="show" identifier="channels" id="AfV-69-qwl"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="egA-1I-S3M" id="MSy-5D-wu6"/>
+                            <outlet property="delegate" destination="egA-1I-S3M" id="fhb-sk-DGo"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="VDq-hE-hOx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1938" y="-750"/>
+        </scene>
+        <!--Notification Channels View Controller-->
+        <scene sceneID="hel-fc-EgI">
+            <objects>
+                <tableViewController id="kBu-Ct-cvV" customClass="NotificationChannelsViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="Ejh-aO-CT4">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" textLabel="zNS-ZQ-yeL" detailTextLabel="XSW-XI-O3I" style="IBUITableViewCellStyleValue1" id="wN3-MZ-2sc">
+                                <rect key="frame" x="0.0" y="50" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wN3-MZ-2sc" id="m1x-Bf-UWm">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="zNS-ZQ-yeL">
+                                            <rect key="frame" x="20" y="15" width="25" height="14.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="XSW-XI-O3I">
+                                            <rect key="frame" x="361" y="15" width="33" height="14.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="kBu-Ct-cvV" id="Ih4-xO-Vcc"/>
+                            <outlet property="delegate" destination="kBu-Ct-cvV" id="LUw-S1-fqr"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="k9x-nM-8rX"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="DNr-zc-IAk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2767" y="-750"/>
         </scene>
     </scenes>
     <resources>

--- a/Example/Example/SceneDelegate.swift
+++ b/Example/Example/SceneDelegate.swift
@@ -49,11 +49,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         switch style {
         case .uiKit:
             let storyboard = UIStoryboard(name: "Main", bundle: nil)
-            guard let viewController = storyboard.instantiateInitialViewController() as? MagicBellStoreViewController else {
+            guard let navController = storyboard.instantiateInitialViewController() as? UINavigationController else {
+                fatalError("Invalid Storyboard")
+            }
+            guard let viewController = navController.topViewController as? MagicBellStoreViewController else {
                 fatalError("Invalid Storyboard")
             }
             viewController.user = user
-            window?.rootViewController = viewController
+            window?.rootViewController = navController
         case .swiftUI:
             let store = user.store.build()
             window?.rootViewController = HostingController(rootView: NavigationView {

--- a/Example/Example/SceneDelegate.swift
+++ b/Example/Example/SceneDelegate.swift
@@ -44,7 +44,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: scene)
 
         // Defining the user to test
-        let user = MagicBellClient.shared.connectUser(email: "richard@example.com")
+        let user = MagicBellClient.shared.connectUser(email: "hi@ullrich.is")
 
         switch style {
         case .uiKit:

--- a/Example/Example/UIKit/MagicBellStoreViewController.swift
+++ b/Example/Example/UIKit/MagicBellStoreViewController.swift
@@ -15,17 +15,12 @@ import UIKit
 import MagicBell
 
 // swiftlint:disable type_body_length
-class MagicBellStoreViewController: UIViewController,
-    UINavigationBarDelegate,
-    UITableViewDelegate,
-    UITableViewDataSource,
-    NotificationStoreContentObserver,
-    NotificationStoreCountObserver {
+class MagicBellStoreViewController: UITableViewController,
+                                    NotificationStoreContentObserver,
+                                    NotificationStoreCountObserver {
 
     private var isLoadingNextPage = false
 
-    @IBOutlet weak var navigationBar: UINavigationBar!
-    @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var magicBellStoreItem: BadgeBarButtonItem!
 
     // swiftlint:disable implicitly_unwrapped_optional
@@ -40,16 +35,11 @@ class MagicBellStoreViewController: UIViewController,
 
     private var observer: AnyObject?
 
-    override var title: String? {
-        didSet { navigationBar.topItem?.title = title }
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
         self.title = "Notifications"
-
-        navigationBar.topItem?.title = self.title
+        self.navigationItem.backButtonTitle = "Notifications"
 
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(refreshAction(sender:)), for: .valueChanged)
@@ -59,6 +49,14 @@ class MagicBellStoreViewController: UIViewController,
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         reloadStore()
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "preferences" {
+            if let destinationVC = segue.destination as? NotificationPreferencesViewController {
+                destinationVC.user = user
+            }
+        }
     }
 
     // swiftlint:disable empty_count
@@ -135,6 +133,10 @@ class MagicBellStoreViewController: UIViewController,
             alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
             self.present(alert, animated: true, completion: nil)
         })
+        
+        alert.addAction(UIAlertAction(title: "Notification Preferences", style: .default) { action in
+            self.performSegue(withIdentifier: "preferences", sender: action)
+        })
 
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
 
@@ -178,19 +180,13 @@ class MagicBellStoreViewController: UIViewController,
         present(alert, animated: true, completion: nil)
     }
 
-    // MARK: UINavigationBarDelegate
-
-    func position(for bar: UIBarPositioning) -> UIBarPosition {
-        .topAttached
-    }
-
     // MARK: UITableViewDataSource
 
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return store.count
     }
 
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "MagicBellStoreCell", for: indexPath) as? MagicBellStoreCell else {
             fatalError("Couldn't dequeue a MagicBellStoreCell")
         }
@@ -221,7 +217,7 @@ class MagicBellStoreViewController: UIViewController,
     // MARK: UITableViewDelegate
 
     // swiftlint:disable cyclomatic_complexity
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
         let notification = store[indexPath.row]
@@ -299,7 +295,7 @@ class MagicBellStoreViewController: UIViewController,
         present(alert, animated: true, completion: nil)
     }
 
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if !isLoadingNextPage &&
             (scrollView.contentOffset.y > scrollView.contentSize.height - scrollView.bounds.size.height - 200) && store.hasNextPage {
             isLoadingNextPage = true

--- a/Example/Example/UIKit/NotificationChannelsViewController.swift
+++ b/Example/Example/UIKit/NotificationChannelsViewController.swift
@@ -9,9 +9,19 @@ import Foundation
 import UIKit
 import MagicBell
 
+protocol NotificationChannelsViewControllerDelegate : AnyObject {
+    func updateChannel(_ sender: NotificationChannelsViewController, categorySlug: String, channelSlug: String, enabled: Bool)
+}
+
 class NotificationChannelsViewController: UITableViewController {
     // swiftlint:disable implicitly_unwrapped_optional
-    var category: MagicBell.Category!
+    var category: MagicBell.Category! {
+        didSet {
+            self.tableView.reloadData()
+        }
+    }
+    
+    weak var delegate: NotificationChannelsViewControllerDelegate?
     
     // MARK: - TableView
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -27,5 +37,12 @@ class NotificationChannelsViewController: UITableViewController {
         cell.textLabel?.text = channel.label
         cell.detailTextLabel?.text = "\(channel.enabled)"
         return cell
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        let channel = self.category.channels[indexPath.row]
+        self.delegate?.updateChannel(self, categorySlug: category.slug, channelSlug: channel.slug, enabled: !channel.enabled)
     }
 }

--- a/Example/Example/UIKit/NotificationChannelsViewController.swift
+++ b/Example/Example/UIKit/NotificationChannelsViewController.swift
@@ -1,0 +1,31 @@
+//
+//  NotificationChannelsViewController.swift
+//  Example
+//
+//  Created by Ullrich Schäfer on 07.04.24.
+//
+
+import Foundation
+import UIKit
+import MagicBell
+
+class NotificationChannelsViewController: UITableViewController {
+    // swiftlint:disable implicitly_unwrapped_optional
+    var category: MagicBell.Category!
+    
+    // MARK: - TableView
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return category?.channels.count ?? 0
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let reuseIdentifier = "cell"
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier) else {
+            fatalError("Could not dequeue table view cell with identifier \(reuseIdentifier)")
+        }
+        guard let channel = category?.channels[indexPath.row] else { return cell }
+        cell.textLabel?.text = channel.label
+        cell.detailTextLabel?.text = "\(channel.enabled)"
+        return cell
+    }
+}

--- a/Example/Example/UIKit/NotificationPreferencesViewController.swift
+++ b/Example/Example/UIKit/NotificationPreferencesViewController.swift
@@ -1,0 +1,58 @@
+//
+//  NotificationPreferencesViewController.swift
+//  Example
+//
+//  Created by Ullrich Schäfer on 06.04.24.
+//
+
+import Foundation
+import UIKit
+import MagicBell
+
+class NotificationPreferencesViewController: UITableViewController {
+    
+    // swiftlint:disable implicitly_unwrapped_optional
+    var user: MagicBell.User!
+    var categories: [MagicBell.Category]?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        user.preferences.fetch { result in
+            switch result {
+            case .failure(let error):
+                print("Error fetching notification preferences: \(error)")
+            case .success(let preferences):
+                self.categories = preferences.categories
+                self.tableView.reloadData()
+            }
+        }
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "channels" {
+            if let destinationVC = segue.destination as? NotificationChannelsViewController {
+                if let indexPath = self.tableView.indexPath(for: sender as! UITableViewCell) {
+                    destinationVC.category = self.categories![indexPath.row]
+                }
+            }
+        }
+    }
+    
+    // MARK: - TableView
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        print("count \(categories?.count)")
+        return categories?.count ?? 0
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let reuseIdentifier = "cell"
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier) else {
+            fatalError("Could not dequeue table view cell with identifier \(reuseIdentifier)")
+        }
+        guard let category = categories?[indexPath.row] else { return cell }
+        cell.textLabel?.text = category.label
+        cell.detailTextLabel?.text = "\(category.channels.count)"
+        return cell
+    }
+}

--- a/Example/Example/UIKit/NotificationPreferencesViewController.swift
+++ b/Example/Example/UIKit/NotificationPreferencesViewController.swift
@@ -8,6 +8,7 @@
 import Foundation
 import UIKit
 import MagicBell
+import ProgressHUD
 
 class NotificationPreferencesViewController: UITableViewController, NotificationChannelsViewControllerDelegate {
     
@@ -72,12 +73,15 @@ class NotificationPreferencesViewController: UITableViewController, Notification
     // MARK: - NotificationChannelsViewControllerDelegate
     
     func updateChannel(_ sender: NotificationChannelsViewController, categorySlug: String, channelSlug: String, enabled: Bool) {
+        ProgressHUD.animate("Updating Preference...", .none, interaction: false)
         user.preferences.update(categorySlug: categorySlug, channelSlug: channelSlug, enabled: enabled) { result in
             switch result {
             case .failure(let error):
                 print("Error fetching notification preferences: \(error)")
+                ProgressHUD.failed()
             case .success(let preferences):
                 self.preferences = preferences
+                ProgressHUD.success()
             }
         }
     }

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -7,6 +7,7 @@ target 'Example' do
     workspace './Example.xcworkspace'
 
     pod 'MagicBell', :path => '../'
+    pod 'ProgressHUD'
     pod 'SwiftLint'
 end
 

--- a/README.md
+++ b/README.md
@@ -575,6 +575,12 @@ To update the preferences, use `update`.
 user.preferences.update(preferences) { result in }
 ```
 
+To update a single channel you can use the provided convenience function `updateChannel`.
+
+```swift
+user.preferences.update(categorySlug: categorySlug, channelSlug: channelSlug, enabled: enabled) { result in }
+```
+
 ## Push Notifications
 
 You can register the device token with MagicBell for mobile push notifications. To do it, set the device token as soon

--- a/Source/Features/NotificationPreferences/Data/NotificationPreferencesEntity.swift
+++ b/Source/Features/NotificationPreferences/Data/NotificationPreferencesEntity.swift
@@ -17,12 +17,26 @@ struct ChannelEntity: Codable {
     let slug:String
     let label:String
     let enabled:Bool
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.slug, forKey: .slug)
+        // try container.encode(self.label, forKey: .label) // explicitly not encoding labels, as they are not expected in PUT calls
+        try container.encode(self.enabled, forKey: .enabled)
+    }
 }
 
 struct CategoryEntity: Codable {
     let slug:String
     let label:String
     let channels:[ChannelEntity]
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.slug, forKey: .slug)
+        // try container.encode(self.label, forKey: .label) // explicitly not encoding labels, as they are not expected in PUT calls
+        try container.encode(self.channels, forKey: .channels)
+    }
 }
 
 struct NotificationPreferencesEntity: Codable {

--- a/Tests/Features/NotificationPreferences/Data/NotificationPreferencesEntityTests.swift
+++ b/Tests/Features/NotificationPreferences/Data/NotificationPreferencesEntityTests.swift
@@ -16,7 +16,7 @@
 import XCTest
 import Nimble
 
-let fixture = """
+let getFixture = """
 {
    "notification_preferences":{
       "categories":[
@@ -41,6 +41,29 @@ let fixture = """
 }
 """
 
+// put payload does not expect labels
+let putFixture = """
+{
+   "notification_preferences":{
+      "categories":[
+         {
+            "slug":"user_liked_post",
+            "channels":[
+               {
+                  "slug":"in_app",
+                  "enabled":true
+               },
+               {
+                  "slug":"mobile_push",
+                  "enabled":false
+               }
+            ]
+         }
+       ]
+    }
+}
+"""
+
 /// Helper function to make json data comparable
 /// re-encodes json data with sorted and stable keys order
 func jsonDataWithSortedKeys(_ data: Data) throws -> Data {
@@ -53,7 +76,7 @@ final class NotificationPreferencesEntityTests: XCTestCase {
     let toDataMapper = EncodableToDataMapper<NotificationPreferencesEntity>()
     
     func testJsonDecoding() throws {
-        let json = fixture.data(using: .utf8)!
+        let json = getFixture.data(using: .utf8)!
         
         let entity = try! toDecodableMapper.map(json)
         
@@ -76,7 +99,6 @@ final class NotificationPreferencesEntityTests: XCTestCase {
     }
     
     func testJsonCoding() throws {
-        
         let channel1 = ChannelEntity(slug: "in_app", label: "In app", enabled: true)
         let channel2 = ChannelEntity(slug: "mobile_push", label: "Mobile push", enabled: false)
         let category = CategoryEntity(slug: "user_liked_post", label: "User Liked Post", channels: [channel1, channel2])
@@ -85,7 +107,7 @@ final class NotificationPreferencesEntityTests: XCTestCase {
         let result = try! toDataMapper.map(entity)
         
         let comparableResult = try! jsonDataWithSortedKeys(result)
-        let comparableExpected = try! jsonDataWithSortedKeys(fixture.data(using: .utf8)!)
+        let comparableExpected = try! jsonDataWithSortedKeys(putFixture.data(using: .utf8)!)
         
         XCTAssertEqual(comparableResult, comparableExpected)
     }


### PR DESCRIPTION
# In this PR

This PR contains two things:
- A new function to easily update a single channel in notification preferences:
```swift
user.preferences.update(categorySlug: categorySlug, channelSlug: channelSlug, enabled: enabled) { result in }
```
- Additions to the Example app to demonstrate that & how it works

# Discussion

The `/notification_preferences` endpoint is funny in the way that a `GET` request returns a different shape than a `PUT` request expects. The former returns `labels` while the later does not expect `labels`. It doesn't hurt passing them, and the `PUT` will simply ignore them, but I've opted for making this behaviour explicit in the docstrings, and unit tests.

The solution I went with simply drops the `label` keys when encoding `NotificationPreferencesEntity` (see changes in Source/Features/NotificationPreferences/Data/NotificationPreferencesEntity.swift). I tried alternative approaches, but the Harmony framework in use is expecting GET and PUT datasources to have the same entity type, making it impossible to have one with, and one without labels (see this [line of code](https://github.com/mobilejazz/harmony-swift/blob/a00a498c7432d25c43f84a0736d3f7d4f40809ae/Sources/Harmony/Data/DataSource/Future/DataSourceAssembler.swift#L22) and the `Get.T == T, Put.T == T`). I've added a comment to the codebase that describes the behaviour.

# Test Plan

Tested in the sample App as shown in this video:

https://github.com/magicbell-io/magicbell-swift/assets/13815/0e36a0d2-4175-486f-b949-cebb2d6f75c7

