### PR TITLE
chore: release v2.0.0

### DIFF
--- a/MagicBell.podspec
+++ b/MagicBell.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.homepage         = 'https://magicbell.com'
   s.license          = { :type => 'Custom', :file => 'LICENSE' }
   s.author           = { 'MagicBell' => 'hello@magicbell.com' }
-  s.source           = { :git => 'https://github.com/magicbell-io/magicbell-swift', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/magicbell-io/magicbell-swift.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/magicbell_io'
 
   s.osx.deployment_target = '10.15'

--- a/MagicBell.podspec
+++ b/MagicBell.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MagicBell'
-  s.version          = '1.0.0'
+  s.version          = '2.0.0'
   s.summary          = 'Official MagicBell SDK for Swift'
   s.description      = 'Official MagicBell SDK for Swift. The notification inbox for your product.'
 

--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ class Notifications: View {
 
 ## Notification Preferences
 
-You can fetch and set users notification preferences for MagicBell channels and categories.
+You can fetch and set notification preferences for MagicBell channels and categories.
 
 ```swift
 public struct Channel {
@@ -556,7 +556,7 @@ public struct NotificationPreferences {
 }
 ```
 
-To fetch the users notification preferences, use the `fetch` method as follows:
+To fetch notification preferences, use the `fetch` method as follows:
 
 ```swift
 user.preferences.fetch { result in
@@ -577,7 +577,7 @@ user.preferences.update(preferences) { result in }
 To update a single channel you can use the provided convenience function `updateChannel`.
 
 ```swift
-user.preferences.update(categorySlug: categorySlug, channelSlug: channelSlug, enabled: enabled) { result in }
+user.preferences.update(categorySlug: "new_comment", channelSlug: "in_app", enabled: true) { result in }
 ```
 
 ## Push Notifications

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This repo also contains a full-blown example. To run the project:
 To install MagicBell using [CocoaPods](https://cocoapods.org), add this entry to your `Podfile`:
 
 ```ruby
-pod 'MagicBell', '>=1.0.0'
+pod 'MagicBell', '>=2.0.0'
 ```
 
 **IMPORTANT**: Make sure you specify `use_frameworks!` in your `Podfile`.
@@ -86,7 +86,7 @@ To install MagicBell using [Swift Package Manager](https://www.swift.org/package
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/magicbell-io/magicbell-swift", .upToNextMajor(from: "1.0.0"))
+    .package(url: "https://github.com/magicbell-io/magicbell-swift", .upToNextMajor(from: "2.0.0"))
 ]
 ```
 
@@ -95,7 +95,7 @@ dependencies: [
 To install MagicBell using [Carthage](https://github.com/Carthage/Carthage), add to the Carfile the following dependency:
 
 ```ruby
-github "magicbell-io/magicbell-swift" "1.0.0"
+github "magicbell-io/magicbell-swift" "2.0.0"
 ```
 
 Then, run `carthage update --use-xcframeworks --platform [iOS|macOS] --no-use-binaries` (selecting the desired platform) to resolve dependencies.

--- a/Source/MagicBellClient.swift
+++ b/Source/MagicBellClient.swift
@@ -22,7 +22,7 @@ let magicBellTag = "MagicBell"
 public class MagicBellClient {
 
     /// The MagicBell SDK version
-    public static let version = "1.0.0"
+    public static let version = "2.0.0"
 
     private let sdkProvider: SDKComponent
 


### PR DESCRIPTION
This PR prepares release **v2.0.0**

I decided to give this a major version bump, as this release changes two APIs in a breaking way:
- The notifications preferences API changed completely, as we're using the v2 shape of the API endpoint now
- The HMAC interface changed as well

Additionally I've added the `.git` suffix to the source in the podspec file. That was a warning `pod spec lint` gave me and I took the chance to address it.

After this PR is merged I will:
- Tag the commit as `2.0.0` with the changelog (see below)
- Publish release to CocoaPods (by running `pod trunk push` after claiming ownership)


# Changelog

## v2.0.0

This release is mostly compatible with version 1.0.0 of the SDK. It introduces two breaking changes though. Please consult the `Readme.md` for detailed reference.

**Breaking: Updated Notification Preferences API**

The shape of the returned preferences object changed and now contains categories and channels.

**Breaking: HMAC validation**

Instead of being required to pass the API secret, the HMAC should be computed on backend and passed to the frontend, where it is expected as an argument on the `connectUser` call.   
Also the `MagicBellClient` does not have a `enableHMAC` flag anymore. The behaviour whether to send an HMAC header is now defined by whether one was passed as an argument to the `connectUser` call.